### PR TITLE
Optparse and Console output

### DIFF
--- a/lib/ordodo.rb
+++ b/lib/ordodo.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'delegate'
 require 'tilt'
+require 'optparse'
 
 require 'cells'
 require 'cells-erb'

--- a/lib/ordodo/cli.rb
+++ b/lib/ordodo/cli.rb
@@ -1,14 +1,56 @@
 module Ordodo
   class CLI
     def self.run!(argv)
+      
+      options = {}
+      optparse = OptionParser.new do|opts|
+        # Set a banner, displayed at the top
+        # of the help screen.
+        opts.banner = "Usage: ordodo [OPTIONS] myconfig.xml"
+      
+        # Define the options, and what they do
+        options[:outputfile] = nil
+        opts.on( '-o', '--output FILE', 'Write output to FILE' ) do|file|
+          options[:outputfile] = file
+        end
+        
+        options[:year] = nil
+        opts.on( '-y', '--year YEAR', 'Specify the YEAR for which the ordo should be produced' ) do|year|
+          options[:year] = Integer(year)
+        end
+        
+        # This displays the help screen
+        opts.on( '-h', '--help', 'Display this screen' ) do
+          puts opts
+          exit
+      end
+    end
+    # Parse the command-line. 
+    optparse.parse!
+      
       config_path = argv[0] || die('Specify path to the configuration file.')
-      year = argv[1]&.to_i
-
-      begin
+      
+      if options[:outputfile]
+      output_dir = File.dirname(options[:outputfile])
+      output_filename = File.basename(options[:outputfile])
+      else
+      output_dir = nil
+      output_filename = "index_" + File.basename(config_path, ".xml") + ".html"
+      end
+      
+      year = options[:year]
+      
+     begin
         config =
           File.open(config_path) do |fr|
           Config.from_xml(fr) do |config|
             config.year = year if year
+            if output_dir
+            config.output_dir = output_dir
+            else
+            config.output_dir = "ordo_#{config.year}"
+            end
+            config.output_filename = output_filename
           end
         end
         Generator.new(config).call

--- a/lib/ordodo/config.rb
+++ b/lib/ordodo/config.rb
@@ -4,10 +4,10 @@ module Ordodo
       @locale = :en
       @temporale_options = {}
       @temporale_extensions = []
-      @calendars = nil
-      @output_directory = nil
       @year = upcoming_year
       @title = 'Liturgical Calendar'
+      @output_dir = nil
+      @output_filename = 'ordodo_out'
 
       @loader = CalendariumRomanum::SanctoraleLoader.new
 
@@ -25,7 +25,8 @@ module Ordodo
                   :temporale_options,
                   :temporale_extensions,
                   :calendars,
-                  :output_directory,
+                  :output_dir,
+                  :output_filename,
                   :title,
                   :year
 

--- a/lib/ordodo/generator.rb
+++ b/lib/ordodo/generator.rb
@@ -27,7 +27,8 @@ module Ordodo
         Outputters::HTML.new(
           @config,
           templates_dir: 'templates/html',
-          output_dir: "ordo_#{@config.year}",
+          output_dir: @config.output_dir,
+          output_filename: @config.output_filename,
           globals: globals,
         )
       ]

--- a/lib/ordodo/outputters/console.rb
+++ b/lib/ordodo/outputters/console.rb
@@ -18,6 +18,12 @@ module Ordodo
           puts
         end
       end
+      
+      def finish
+      
+          puts "Ordo written to #{@output_dir}/#{@output_filename}"
+      
+      end
 
       private
 

--- a/lib/ordodo/outputters/html.rb
+++ b/lib/ordodo/outputters/html.rb
@@ -3,7 +3,8 @@ module Ordodo
     class HTML < Outputter
       def prepare
         FileUtils.mkdir_p(@output_dir)
-        @fw = File.open(File.join(@output_dir, 'index.html'), 'w')
+	   # filename = 'index_' + @output_filename + '.html'
+        @fw = File.open(File.join(@output_dir, @output_filename), 'w')
 
         @fw.puts header.render(self, **@globals)
       end

--- a/lib/ordodo/outputters/outputter.rb
+++ b/lib/ordodo/outputters/outputter.rb
@@ -3,9 +3,10 @@ module Ordodo
     class Outputter
       extend Forwardable
 
-      def initialize(config, output_dir: nil, templates_dir: nil, globals: {})
+      def initialize(config, output_dir: nil, output_filename:nil, templates_dir: nil, globals: {})
         @config = config
         @output_dir = output_dir
+        @output_filename = output_filename
         @templates_dir = templates_dir
         @globals = globals
       end


### PR DESCRIPTION
Hi,

so I finally got into Ruby and your code. Here is my first commit.

* I inserted optparse. It's also used for the year specification.
Former: `$ordodo example.xml 2050`
Now: `$ordodo -y 2050 example.xml`
* Output specification works like this:
`$ordodo -o path/to/file.html example.xml`
* Console has now a finish method and states the location of the output.
* Basic usage `$ordodo example.xml` will now result into an output `ordo_YEAR/index_example.html`

I tested everything, should be working.

What is missing is changing the README. I wanted to wait for your feedback.

Regards,

martindonat